### PR TITLE
🐛 fix NPE when running on windows system

### DIFF
--- a/core/src/main/java/be/darkkraft/transferproxy/main/Main.java
+++ b/core/src/main/java/be/darkkraft/transferproxy/main/Main.java
@@ -38,7 +38,7 @@ import java.nio.file.Path;
 public final class Main {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
-    private static final Path CONFIG_PATH = Path.of("config.yml");
+    private static final Path CONFIG_PATH = Path.of("./config.yml");
 
     public static void main(final String[] args) {
         final ProxyConfiguration configuration;


### PR DESCRIPTION
An error occurred when generating the configuration file under Windows 11 system
```java
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.getFileSystem()" because "path" is null
        at java.base/java.nio.file.Files.provider(Files.java:105)
        at java.base/java.nio.file.Files.notExists(Files.java:2576)
        at be.darkkraft.transferproxy.api.util.ResourceUtil.copyResource(ResourceUtil.java:80)
        at be.darkkraft.transferproxy.api.util.ResourceUtil.copyResource(ResourceUtil.java:62)
        at be.darkkraft.transferproxy.api.util.ResourceUtil.copyAndReadYaml(ResourceUtil.java:106)
        at be.darkkraft.transferproxy.main.Main.main(Main.java:46)
```